### PR TITLE
feat: [BE] Support country filter on the get top-ups endpoint for the universal sim "GET/v2/sims/:iccid/topups" in SDK (AP-7797)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,8 +561,8 @@ usage = alo.sim_usage_bulk(["870000000001", "870000000002", "870000000003", "870
 `def get_sim_topups(iccid: str, iso2_country_code: Optional[str] = None)  -> dict | None`<br>
 Fetches available top‑ups for an `iccid`. Full response: https://developers.partners.airalo.com/get-top-up-package-list-11883031e0<br><br>
 Parameters:<br>
-`iccid` - the `iccid` from the eSim order<br>
-`iso2_country_code` - optional parameter to filter topups for a specific iso2 country code. Only applicable if the `iccid` is from a universal eSim<br>
+`iccid` - the `iccid` from the eSIM order<br>
+`iso2_country_code` - optional parameter to filter topups for a specific iso2 country code. Only applicable if the `iccid` is from a universal eSIM<br>
 
 ```python
 available_topups = alo.get_sim_topups(iccid)

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ Fetching local packages. Same behavior as above.
 `def get_global_packages(flat: bool = False, limit: int | None = None, page: int | None = None) -> dict | None`  
 Fetching global packages. Same behavior as above.
 
+`def get_universal_packages(flat: bool = False, limit: int | None = None, page: int | None = None) -> dict | None`  
+Fetching universal packages. Same behavior as above.
+
 `def get_country_packages(country_code: str, flat: bool = False, limit: int | None = None) -> dict | None`  
 Fetching country‑specific packages. Same behavior as above.
 
@@ -555,8 +558,12 @@ usage = alo.sim_usage_bulk(["870000000001", "870000000002", "870000000003", "870
 
 <h2> Sim Topups </h2>
 
-`def get_sim_topups(iccid: str) -> dict | None`  
-Fetches available top‑ups for an `iccid`. Full response: https://developers.partners.airalo.com/get-top-up-package-list-11883031e0
+`def get_sim_topups(iccid: str, iso2_country_code: Optional[str] = None)  -> dict | None`<br>
+Fetches available top‑ups for an `iccid`. Full response: https://developers.partners.airalo.com/get-top-up-package-list-11883031e0<br><br>
+Parameters:<br>
+`iccid` - the `iccid` from the eSim order<br>
+`iso2_country_code` - optional parameter to filter topups for a specific iso2 country code. Only applicable if the `iccid` is from a universal eSim<br>
+
 ```python
 available_topups = alo.get_sim_topups(iccid)
 ```

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ Fetching local packages. Same behavior as above.
 Fetching global packages. Same behavior as above.
 
 `def get_universal_packages(flat: bool = False, limit: int | None = None, page: int | None = None) -> dict | None`  
-Fetching universal packages. Same behavior as above.
+Fetching universal packages.<br/>
+This method will return no results unless Universal Packages are enabled for your account by your Account Manager.
 
 `def get_country_packages(country_code: str, flat: bool = False, limit: int | None = None) -> dict | None`  
 Fetching country‑specific packages. Same behavior as above.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Fetching global packages. Same behavior as above.
 
 `def get_universal_packages(flat: bool = False, limit: int | None = None, page: int | None = None) -> dict | None`  
 Fetching universal packages.<br/>
-This method will return no results unless Universal Packages are enabled for your account by your Account Manager.
+Note: This method will return no results unless Universal Packages are enabled for your account by your Account Manager.
 
 `def get_country_packages(country_code: str, flat: bool = False, limit: int | None = None) -> dict | None`  
 Fetching country‑specific packages. Same behavior as above.

--- a/airalo/airalo.py
+++ b/airalo/airalo.py
@@ -571,14 +571,14 @@ class Airalo:
 
     def get_sim_topups(self, iccid: str, iso2_country_code: Optional[str] = None) -> Optional[Dict]:
         """
-        Get SIM topup history.
+        Get available topups for a SIM.
 
         Args:
             iccid: ICCID of the SIM
-            iso2_country_code: ISO2 country code (optional) Works only with iccid from universal eSim
+            iso2_country_code: Optional ISO2 country code to filter topups. Only applicable for universal eSIMs.
 
         Returns:
-            Topup history or None
+            Available topups or None
         """
         return self._sim.get_topups(iccid, iso2_country_code)
 

--- a/airalo/airalo.py
+++ b/airalo/airalo.py
@@ -246,6 +246,25 @@ class Airalo:
         """
         return self._packages.get_global_packages(flat, limit, page)
 
+    def get_universal_packages(
+        self,
+        flat: bool = False,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+    ) -> Optional[Dict]:
+        """
+        Get universal packages.
+
+        Args:
+            flat: If True, return flattened response
+            limit: Number of results per page
+            page: Page number
+
+        Returns:
+            Packages data or None
+        """
+        return self._packages.get_universal_packages(flat, limit, page)
+
     def get_country_packages(
         self, country_code: str, flat: bool = False, limit: Optional[int] = None
     ) -> Optional[Dict]:
@@ -550,17 +569,18 @@ class Airalo:
         """
         return self._sim.get_usage_bulk(iccids)
 
-    def get_sim_topups(self, iccid: str) -> Optional[Dict]:
+    def get_sim_topups(self, iccid: str, iso2_country_code: Optional[str] = None) -> Optional[Dict]:
         """
         Get SIM topup history.
 
         Args:
             iccid: ICCID of the SIM
+            iso2_country_code: ISO2 country code (optional) Works only with iccid from universal eSim
 
         Returns:
             Topup history or None
         """
-        return self._sim.get_topups(iccid)
+        return self._sim.get_topups(iccid, iso2_country_code)
 
     def get_sim_package_history(self, iccid: str) -> Optional[Dict]:
         """

--- a/airalo/services/packages_service.py
+++ b/airalo/services/packages_service.py
@@ -338,6 +338,27 @@ class PackagesService:
             {"flat": flat, "limit": limit, "page": page, "type": "global"}
         )
 
+    def get_universal_packages(
+        self,
+        flat: bool = False,
+        limit: Optional[int] = None,
+        page: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """
+        Get universal packages only.
+
+        Args:
+            flat: If True, return flattened response
+            limit: Number of results
+            page: Page number
+
+        Returns:
+            Packages data or None
+        """
+        return self.get_packages(
+            {"flat": flat, "limit": limit, "page": page, "type": "universal"}
+        )
+
     def get_country_packages(
         self, country_code: str, flat: bool = False, limit: Optional[int] = None
     ) -> Optional[Dict[str, Any]]:

--- a/airalo/services/sim_service.py
+++ b/airalo/services/sim_service.py
@@ -7,6 +7,7 @@ topup history, and package history.
 
 import json
 from typing import Any, Dict, List, Optional
+from urllib.parse import urlencode
 
 from ..config import Config
 from ..helpers.cached import Cached
@@ -255,6 +256,9 @@ class SimService:
         if endpoint:
             url = f"{url}/{endpoint}"
 
+        if endpoint == ApiConstants.SIMS_TOPUPS and 'filter[country]' in params and params['filter[country]']:
+            url += '?' + urlencode({'filter[country]': params['filter[country]']})
+
         return url
 
     def _is_valid_iccid(self, iccid: Any) -> bool:
@@ -324,17 +328,23 @@ class SimService:
         """
         return self.sim_usage_bulk(iccids)
 
-    def get_topups(self, iccid: str) -> Optional[Dict[str, Any]]:
+    def get_topups(self, iccid: str, iso2_country_code: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """
         Get SIM topup history (convenience method).
 
         Args:
             iccid: ICCID of the SIM
+            iso2_country_code: Optional 2-letter country code to filter universal eSim topups
 
         Returns:
             Topup history or None
         """
-        return self.sim_topups({"iccid": iccid})
+        params = {"iccid": iccid}
+
+        if iso2_country_code:
+            params["filter[country]"] = iso2_country_code
+
+        return self.sim_topups(params)
 
     def get_package_history(self, iccid: str) -> Optional[Dict[str, Any]]:
         """

--- a/airalo/services/sim_service.py
+++ b/airalo/services/sim_service.py
@@ -330,14 +330,14 @@ class SimService:
 
     def get_topups(self, iccid: str, iso2_country_code: Optional[str] = None) -> Optional[Dict[str, Any]]:
         """
-        Get SIM topup history (convenience method).
+        Get available topups for a SIM (convenience method).
 
         Args:
             iccid: ICCID of the SIM
-            iso2_country_code: Optional 2-letter country code to filter universal eSim topups
+            iso2_country_code: Optional 2-letter country code to filter universal eSIM topups.
 
         Returns:
-            Topup history or None
+            Available topups or None
         """
         params = {"iccid": iccid}
 

--- a/tests/services/test_package_service.py
+++ b/tests/services/test_package_service.py
@@ -227,9 +227,11 @@ def test_convenience_methods_delegate_to_get_packages(service, monkeypatch):
     service.get_local_packages(flat=True, limit=5, page=None)
     service.get_global_packages(flat=False, limit=None, page=None)
     service.get_country_packages("us", flat=True, limit=7)
+    service.get_universal_packages(flat=False, limit=None, page=None)
 
     assert called[0] == {"flat": True, "limit": 10, "page": 2}
     assert called[1] == {"flat": False, "limit": None, "page": 3, "simOnly": True}
     assert called[2] == {"flat": True, "limit": 5, "page": None, "type": "local"}
     assert called[3] == {"flat": False, "limit": None, "page": None, "type": "global"}
     assert called[4] == {"flat": True, "limit": 7, "country": "US"}
+    assert called[5] == {"flat": False, "limit": None, "page": None, "type": "universal"}

--- a/tests/test_airalo.py
+++ b/tests/test_airalo.py
@@ -146,11 +146,14 @@ def test_package_methods_delegate_and_return(wire_minimal_monkeypatch):
     out3 = c.get_local_packages(flat=True, limit=7, page=None)
     out4 = c.get_global_packages(flat=False, limit=None, page=None)
     out5 = c.get_country_packages("us", flat=True, limit=9)
+    out6 = c.get_universal_packages(flat=False, limit=None, page=None)
+
     assert out1["called"] == "get_all_packages"
     assert out2["called"] == "get_sim_packages"
     assert out3["called"] == "get_local_packages"
     assert out4["called"] == "get_global_packages"
     assert out5["called"] == "get_country_packages"
+    assert out6["called"] == "get_universal_packages"
 
 
 # ---------- order methods delegation ----------


### PR DESCRIPTION
Support country filter on the get top-ups endpoint to filter out top-ups for the universal sim "GET/v2/sims/:iccid/topups" in SDK (AP-7797)
Add get_universal_packages function to return only universal packages