### PR TITLE
feat: [SDK][Sandbox] AiraloException: The parameter "iccid" is invalid. on call AiraloStatic.getSimTopups() (AP-6133)

### DIFF
--- a/airalo/__init__.py
+++ b/airalo/__init__.py
@@ -15,7 +15,7 @@ from .exceptions.airalo_exception import (
     NetworkError,
 )
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 __all__ = [
     "Airalo",

--- a/airalo/constants/sdk_constants.py
+++ b/airalo/constants/sdk_constants.py
@@ -9,7 +9,7 @@ class SdkConstants:
     """SDK-specific constants for Airalo SDK."""
 
     # SDK Version
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
 
     # Order limits
     BULK_ORDER_LIMIT = 50

--- a/airalo/services/sim_service.py
+++ b/airalo/services/sim_service.py
@@ -273,8 +273,8 @@ class SimService:
         # Convert to string and check
         iccid_str = str(iccid)
 
-        # ICCID should be 18-22 digits
-        return iccid_str.isdigit() and 18 <= len(iccid_str) <= 22
+        # ICCID should be 16-22 digits
+        return iccid_str.isdigit() and 16 <= len(iccid_str) <= 22
 
     def _get_cache_key(self, url: str, params: Dict[str, Any]) -> str:
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "airalo-sdk"
-version = "1.0.2"
+version = "1.0.3"
 description = "Official Airalo Python SDK for Airalo's REST API"
 readme = "README.md"
 requires-python = ">=3.8"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="airalo-python-sdk",
-    version="1.0.2",
+    version="1.0.3",
     author="Airalo",
     author_email="developer@airalo.com",
     description="Python SDK for Airalo Partner API",

--- a/tests/services/test_sim_service.py
+++ b/tests/services/test_sim_service.py
@@ -77,9 +77,11 @@ def test_init_requires_token(mock_config, mock_http, mock_multi_http):
         ("89014103211118510720", True),  # 20 digits
         ("123456789012345678", True),  # 18
         ("1" * 22, True),  # 22
+        ("1" * 16, True),  # 16 (lower boundary)
+        ("12345678901234567", True),  # 17
         ("", False),
         (None, False),
-        ("12345678901234567", False),  # 17
+        ("1" * 15, False),  # 15 (below lower boundary)
         ("1" * 23, False),  # 23
         ("89014103211118510x20", False),  # non-digit
     ],


### PR DESCRIPTION
[…](feat: [SDK][Sandbox] AiraloException: The parameter "iccid" is invalid. on call AiraloStatic.getSimTopups() (AP-6133))